### PR TITLE
added toon json encoder

### DIFF
--- a/src/contexinator/utils/toon_encoder.py
+++ b/src/contexinator/utils/toon_encoder.py
@@ -1,0 +1,126 @@
+"""
+TOON (Token-Oriented Object Notation) encoder for Contextinator.
+
+Converts JSON structures to compact TOON format, saving 40-60% tokens.
+"""
+
+from typing import Any, Dict, List, Union
+
+
+def encode_value(value: Any, key: str = "") -> str:
+    """
+    Encode a single value to TOON format.
+    
+    Args:
+        value: Value to encode
+        key: Optional key name for context
+        
+    Returns:
+        TOON-encoded string
+    """
+    if value is None:
+        return "null"
+    elif isinstance(value, bool):
+        return "true" if value else "false"
+    elif isinstance(value, (int, float)):
+        return str(value)
+    elif isinstance(value, str):
+        # Only quote if contains special chars
+        if any(c in value for c in [',', ':', '[', ']', '{', '}', ' ']):
+            return f'"{value}"'
+        return value
+    elif isinstance(value, list):
+        return encode_list(value, key)
+    elif isinstance(value, dict):
+        return encode_dict(value, key)
+    return str(value)
+
+
+def encode_list(items: List[Any], key: str = "") -> str:
+    """
+    Encode list to TOON format: key[n]: item1,item2,item3
+    
+    Args:
+        items: List to encode
+        key: Key name for the list
+        
+    Returns:
+        TOON-encoded list string
+    """
+    if not items:
+        return f"{key}[0]:" if key else "[]"
+    
+    # Simple values - compact format
+    if all(isinstance(item, (str, int, float, bool)) for item in items):
+        encoded_items = [encode_value(item) for item in items]
+        if key:
+            return f"{key}[{len(items)}]: {','.join(encoded_items)}"
+        return ','.join(encoded_items)
+    
+    # Complex values - line by line
+    result = []
+    for i, item in enumerate(items):
+        if isinstance(item, dict):
+            result.append(f"{key}[{i}]: {encode_dict(item)}")
+        else:
+            result.append(f"{key}[{i}]: {encode_value(item)}")
+    return '\n'.join(result)
+
+
+def encode_dict(obj: Dict[str, Any], prefix: str = "") -> str:
+    """
+    Encode dictionary to TOON format with dot notation.
+    
+    Args:
+        obj: Dictionary to encode
+        prefix: Prefix for nested keys
+        
+    Returns:
+        TOON-encoded dictionary string
+    """
+    if not obj:
+        return "{}"
+    
+    lines = []
+    for key, value in obj.items():
+        full_key = f"{prefix}.{key}" if prefix else key
+        
+        if isinstance(value, dict):
+            # Nested object - flatten with dot notation
+            lines.append(encode_dict(value, full_key))
+        elif isinstance(value, list):
+            # List - use compact array notation
+            lines.append(encode_list(value, full_key))
+        else:
+            # Simple value
+            lines.append(f"{full_key}: {encode_value(value)}")
+    
+    return '\n'.join(lines)
+
+
+def toon_encode(data: Union[Dict, List], root_key: str = "data") -> str:
+    """
+    Main TOON encoding function.
+    
+    Args:
+        data: Data structure to encode (dict or list)
+        root_key: Root key name for the structure
+        
+    Returns:
+        TOON-encoded string
+        
+    Example:
+        >>> data = {"tags": ["jazz", "chill", "lofi"], "count": 3}
+        >>> print(toon_encode(data))
+        tags[3]: jazz,chill,lofi
+        count: 3
+    """
+    if isinstance(data, dict):
+        return encode_dict(data)
+    elif isinstance(data, list):
+        return encode_list(data, root_key)
+    else:
+        return encode_value(data)
+
+
+__all__ = ['toon_encode']

--- a/src/contextinator/cli.py
+++ b/src/contextinator/cli.py
@@ -235,7 +235,7 @@ def query_func(args):
 def search_func(args):
     """Semantic search using natural language queries."""
     from .tools import semantic_search
-    from .utils.output_formatter import format_search_results, export_results_json
+    from .utils.output_formatter import format_search_results, export_results_json, export_results_toon
     
     try:
         query = ' '.join(args.query_text) if isinstance(args.query_text, list) else args.query_text
@@ -247,14 +247,20 @@ def search_func(args):
             language=getattr(args, 'language', None),
         )
         
+        result_data = {
+            'query': query,
+            'collection': args.collection,
+            'total_results': len(results),
+            'results': results
+        }
+        
         if args.json:
-            export_results_json({
-                'query': query,
-                'collection': args.collection,
-                'total_results': len(results),
-                'results': results
-            }, args.json)
-        else:
+            export_results_json(result_data, args.json)
+        
+        if getattr(args, 'toon', None):
+            export_results_toon(result_data, args.toon)
+        
+        if not args.json and not getattr(args, 'toon', None):
             format_search_results(results, query=query, collection=args.collection)
         
     except Exception as e:
@@ -265,7 +271,7 @@ def search_func(args):
 def symbol_func(args):
     """Find symbols (functions/classes) by name."""
     from .tools import symbol_search
-    from .utils.output_formatter import format_search_results, export_results_json
+    from .utils.output_formatter import format_search_results, export_results_json, export_results_toon
     
     try:
         results = symbol_search(
@@ -274,14 +280,20 @@ def symbol_func(args):
             symbol_type=getattr(args, 'type', None),
         )
         
+        result_data = {
+            'symbol': args.symbol_name,
+            'collection': args.collection,
+            'total_results': len(results),
+            'results': results
+        }
+        
         if args.json:
-            export_results_json({
-                'symbol': args.symbol_name,
-                'collection': args.collection,
-                'total_results': len(results),
-                'results': results
-            }, args.json)
-        else:
+            export_results_json(result_data, args.json)
+        
+        if getattr(args, 'toon', None):
+            export_results_toon(result_data, args.toon)
+        
+        if not args.json and not getattr(args, 'toon', None):
             format_search_results(results, query=f"Symbol: {args.symbol_name}", collection=args.collection)
         
     except Exception as e:
@@ -292,7 +304,7 @@ def symbol_func(args):
 def pattern_func(args):
     """Search for code patterns using regex."""
     from .tools import regex_search
-    from .utils.output_formatter import format_search_results, export_results_json
+    from .utils.output_formatter import format_search_results, export_results_json, export_results_toon
     
     try:
         results = regex_search(
@@ -302,14 +314,20 @@ def pattern_func(args):
             file_path=getattr(args, 'file', None)
         )
         
+        result_data = {
+            'pattern': args.pattern,
+            'collection': args.collection,
+            'total_results': len(results),
+            'results': results
+        }
+        
         if args.json:
-            export_results_json({
-                'pattern': args.pattern,
-                'collection': args.collection,
-                'total_results': len(results),
-                'results': results
-            }, args.json)
-        else:
+            export_results_json(result_data, args.json)
+        
+        if getattr(args, 'toon', None):
+            export_results_toon(result_data, args.toon)
+        
+        if not args.json and not getattr(args, 'toon', None):
             format_search_results(results, query=f"Pattern: {args.pattern}", collection=args.collection)
         
     except Exception as e:
@@ -320,7 +338,7 @@ def pattern_func(args):
 def read_file_func(args):
     """Reconstruct and display complete file from chunks."""
     from .tools import read_file
-    from .utils.output_formatter import format_file_content, export_results_json
+    from .utils.output_formatter import format_file_content, export_results_json, export_results_toon
     
     try:
         file_data = read_file(
@@ -331,7 +349,11 @@ def read_file_func(args):
         
         if args.json:
             export_results_json(file_data, args.json)
-        else:
+        
+        if getattr(args, 'toon', None):
+            export_results_toon(file_data, args.toon)
+        
+        if not args.json and not getattr(args, 'toon', None):
             format_file_content(file_data)
         
     except Exception as e:
@@ -342,7 +364,7 @@ def read_file_func(args):
 def search_advanced_func(args):
     """Advanced search with multiple criteria."""
     from .tools import hybrid_search, full_text_search
-    from .utils.output_formatter import format_search_results, export_results_json
+    from .utils.output_formatter import format_search_results, export_results_json, export_results_toon
     
     try:
         # Use hybrid search if semantic query provided
@@ -381,14 +403,20 @@ def search_advanced_func(args):
             )
             query_desc = f"Advanced: {args.pattern or 'metadata filters'}"
         
+        result_data = {
+            'query': query_desc,
+            'collection': args.collection,
+            'total_results': len(results),
+            'results': results
+        }
+        
         if args.json:
-            export_results_json({
-                'query': query_desc,
-                'collection': args.collection,
-                'total_results': len(results),
-                'results': results
-            }, args.json)
-        else:
+            export_results_json(result_data, args.json)
+        
+        if getattr(args, 'toon', None):
+            export_results_toon(result_data, args.toon)
+        
+        if not args.json and not getattr(args, 'toon', None):
             format_search_results(results, query=query_desc, collection=args.collection)
         
     except Exception as e:
@@ -661,6 +689,7 @@ def main():
     p_search.add_argument('--file', '-f', help='Filter by file path (partial match)')
     p_search.add_argument('--type', '-t', help='Filter by node type')
     p_search.add_argument('--json', help='Export results to JSON file')
+    p_search.add_argument('--toon', help='Export results to TOON file (compact format)')
     p_search.set_defaults(func=search_func)
 
     # symbol (symbol search)
@@ -671,6 +700,7 @@ def main():
     p_symbol.add_argument('--file', '-f', help='Filter by file path (partial match)')
     p_symbol.add_argument('--limit', type=int, default=50, help='Maximum results (default: 50)')
     p_symbol.add_argument('--json', help='Export results to JSON file')
+    p_symbol.add_argument('--toon', help='Export results to TOON file (compact format)')
     p_symbol.set_defaults(func=symbol_func)
 
     # pattern (regex search)
@@ -682,6 +712,7 @@ def main():
     p_pattern.add_argument('--type', '-t', help='Filter by node type')
     p_pattern.add_argument('--limit', type=int, default=50, help='Maximum results (default: 50)')
     p_pattern.add_argument('--json', help='Export results to JSON file')
+    p_pattern.add_argument('--toon', help='Export results to TOON file (compact format)')
     p_pattern.set_defaults(func=pattern_func)
 
     # read-file (file reconstruction)
@@ -690,6 +721,7 @@ def main():
     p_read_file.add_argument('--collection', '-c', required=True, help='Collection name')
     p_read_file.add_argument('--no-join', action='store_true', help='Show chunks separately (don\'t join)')
     p_read_file.add_argument('--json', help='Export to JSON file')
+    p_read_file.add_argument('--toon', help='Export to TOON file (compact format)')
     p_read_file.set_defaults(func=read_file_func)
 
     # search-advanced (advanced/hybrid search)
@@ -702,6 +734,7 @@ def main():
     p_search_adv.add_argument('--type', '-t', help='Filter by node type')
     p_search_adv.add_argument('--limit', type=int, default=50, help='Maximum results (default: 50)')
     p_search_adv.add_argument('--json', help='Export results to JSON file')
+    p_search_adv.add_argument('--toon', help='Export results to TOON file (compact format)')
     p_search_adv.set_defaults(func=search_advanced_func)
 
     args = parser.parse_args()

--- a/src/contextinator/utils/__init__.py
+++ b/src/contextinator/utils/__init__.py
@@ -25,6 +25,7 @@ from .repo_utils import (
     resolve_repo_path,
 )
 from .token_counter import count_tokens
+from .toon_encoder import toon_encode
 
 __all__ = [
     'ConfigurationError',
@@ -44,4 +45,5 @@ __all__ = [
     'ProgressTracker',
     'resolve_repo_path',
     'setup_logger',
+    'toon_encode',
 ]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds TOON encoding and CLI export to produce compact results that cut token usage by ~40–60%. New --toon flag is available on search, symbol, pattern, read-file, and search-advanced.

- **New Features**
  - TOON encoder added (toon_encode) with dot-notation for objects and compact list syntax; minimal quoting for strings.
  - CLI export: --toon writes TOON to a file and suppresses console output; works alongside --json.

- **Migration**
  - Use --toon <path> to save command results in TOON format.

<sup>Written for commit c18eda843d57b7bb5267ae66e3e39512e776fe6d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

