### PR TITLE
added toon formater from toon official

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Turn any codebase into semantically-aware, searchable knowledge for AI-powered w
 - 🚀 **Full Pipeline Automation** - One command to chunk, embed, and store
 - 🎯 **Smart Deduplication** - Hash-based detection of duplicate code
 - 📊 **Visual AST Explorer** - Debug and visualize code structure
+- 📦 **TOON Format Export** - Token-efficient output format for LLM prompts (40-60% savings)
 
 - 🐳 **Docker-Ready** - ChromaDB server included
 
@@ -141,6 +142,10 @@ python -m src.contextinator.cli pattern "pattern" --collection <name>
 python -m src.contextinator.cli read-file <file-path> --collection <name>
 
 # Advanced search
+
+# Export results in TOON format (40-60% token savings for LLMs)
+python -m src.contextinator.cli search "query" --collection <name> --toon results.json
+python -m src.contextinator.cli symbol <name> --collection <name> --toon symbols.json
 python -m src.contextinator.cli search-advanced --collection <name> --semantic "query" --language python
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "python-dotenv>=1.2.0",
     "flask>=3.1.0",
     "requests>=2.32.0",
+    "toon-format>=0.9.0b1",
     "tree-sitter-python>=0.25.0",
     "tree-sitter-javascript>=0.25.0",
     "tree-sitter-typescript>=0.23.0",

--- a/results.json
+++ b/results.json
@@ -1,0 +1,74 @@
+{
+  "query": "authentication",
+  "collection": "flash",
+  "total_results": 3,
+  "results": [
+    {
+      "id": "chunk_80_3327796426186998725",
+      "content": "async isadminUser(id) {\n    let stmt = this._stmts.get('isadminUser');\n    if (!stmt) {\n      stmt = { name: 'isadminUser', text: `SELECT isadmin FROM users WHERE id = $1 LIMIT 1;` };\n      this._stmts.set('isadminUser', stmt);\n    }\n    stmt.values = [id];\n    const r = await this.db.query(stmt);\n    return r.rows[0] ? r.rows[0].isadmin : null;\n  }",
+      "metadata": {
+        "node_name": "isadminUser",
+        "locations": "[\"example/ts/flash_gen/spacical.js:9-18\"]",
+        "original_index": 80,
+        "end_byte": 486,
+        "file_path": "example/ts/flash_gen/spacical.js",
+        "content": "async isadminUser(id) {\n    let stmt = this._stmts.get('isadminUser');\n    if (!stmt) {\n      stmt = { name: 'isadminUser', text: `SELECT isadmin FROM users WHERE id = $1 LIMIT 1;` };\n      this._stmts.set('isadminUser', stmt);\n    }\n    stmt.values = [id];\n    const r = await this.db.query(stmt);\n    return r.rows[0] ? r.rows[0].isadmin : null;\n  }",
+        "start_byte": 135,
+        "end_line": 18,
+        "hash": "d4b54fd9a9eb188615dab624c00bfdd4d6d52fe185059dbc2c909a5e6285761c",
+        "language": "javascript",
+        "node_type": "method_definition",
+        "embedding_model": "text-embedding-3-large",
+        "start_line": 9
+      },
+      "distance": 1.4247214,
+      "cosine_similarity": -0.4247213999999999
+    },
+    {
+      "id": "chunk_3_-1924290327153194936",
+      "content": "      this._stmts.set('getMostCommentedPosts', stmt);\n    }\n    const r = await this.db.query(stmt, [limit]);\n    return r.rows;\n  }\n\n  async checkUserExists(email) {\n    let stmt = this._stmts.get('checkUserExists');\n    if (!stmt) {\n      stmt = { name: 'checkUserExists', text: `SELECT EXISTS(SELECT 1 FROM users WHERE email = $1) as exists;` };\n      this._stmts.set('checkUserExists', stmt);\n    }\n    stmt.values = [email];\n    const r = await this.db.query(stmt);\n    return r.rows[0] ? r.rows[0].exists : null;\n  }\n\n  async getUsersCreatedBetween(created_at_start, created_at_end) {\n    let stmt = this._stmts.get('getUsersCreatedBetween');\n    if (!stmt) {\n      stmt = `SELECT id, name, email, created_at FROM users WHERE created_at BETWEEN $1 AND $2 ORDER BY created_at DESC;`;\n      this._stmts.set('getUsersCreatedBetween', stmt);\n    }\n    const r = await this.db.query(stmt, [created_at_start, created_at_end]);\n    return r.rows;\n  }\n\n  async updateUserAdminStatus(id, isadmin) {\n    let stmt = this._stmts.get('updateUserAdminStatus');\n    if (!stmt) {\n      stmt = `UPDATE users SET isadmin = $2, updated_at = NOW() WHERE id = $1;`;\n      this._stmts.set('updateUserAdminStatus', stmt);\n    }\n    const r = await this.db.query(stmt, [id, isadmin]);\n    return r.rowCount;\n  }\n\n  async deleteInactiveUsers(created_at) {\n    let stmt = this._stmts.get('deleteInactiveUsers');\n    if (!stmt) {\n      stmt = `DELETE FROM users WHERE id NOT IN ( SELECT DISTINCT user_id FROM posts UNION SELECT DISTINCT user_id FROM comments ) AND created_at < $1;`;\n      this._stmts.set('deleteInactiveUsers', stmt);\n    }\n    const r = await this.db.query(stmt, [created_at]);\n    return r.rowCount;\n  }\n\n  async createUser(name, email, address, isadmin) {\n    let stmt = this._stmts.get('createUser');\n    if (!stmt) {",
+      "metadata": {
+        "is_split": true,
+        "node_type": "class_declaration",
+        "start_byte": 45,
+        "token_count": 485,
+        "content": "      this._stmts.set('getMostCommentedPosts', stmt);\n    }\n    const r = await this.db.query(stmt, [limit]);\n    return r.rows;\n  }\n\n  async checkUserExists(email) {\n    let stmt = this._stmts.get('checkUserExists');\n    if (!stmt) {\n      stmt = { name: 'checkUserExists', text: `SELECT EXISTS(SELECT 1 FROM users WHERE email = $1) as exists;` };\n      this._stmts.set('checkUserExists', stmt);\n    }\n    stmt.values = [email];\n    const r = await this.db.query(stmt);\n    return r.rows[0] ? r.rows[0].exists : null;\n  }\n\n  async getUsersCreatedBetween(created_at_start, created_at_end) {\n    let stmt = this._stmts.get('getUsersCreatedBetween');\n    if (!stmt) {\n      stmt = `SELECT id, name, email, created_at FROM users WHERE created_at BETWEEN $1 AND $2 ORDER BY created_at DESC;`;\n      this._stmts.set('getUsersCreatedBetween', stmt);\n    }\n    const r = await this.db.query(stmt, [created_at_start, created_at_end]);\n    return r.rows;\n  }\n\n  async updateUserAdminStatus(id, isadmin) {\n    let stmt = this._stmts.get('updateUserAdminStatus');\n    if (!stmt) {\n      stmt = `UPDATE users SET isadmin = $2, updated_at = NOW() WHERE id = $1;`;\n      this._stmts.set('updateUserAdminStatus', stmt);\n    }\n    const r = await this.db.query(stmt, [id, isadmin]);\n    return r.rowCount;\n  }\n\n  async deleteInactiveUsers(created_at) {\n    let stmt = this._stmts.get('deleteInactiveUsers');\n    if (!stmt) {\n      stmt = `DELETE FROM users WHERE id NOT IN ( SELECT DISTINCT user_id FROM posts UNION SELECT DISTINCT user_id FROM comments ) AND created_at < $1;`;\n      this._stmts.set('deleteInactiveUsers', stmt);\n    }\n    const r = await this.db.query(stmt, [created_at]);\n    return r.rowCount;\n  }\n\n  async createUser(name, email, address, isadmin) {\n    let stmt = this._stmts.get('createUser');\n    if (!stmt) {",
+        "file_path": "example/ts/flash_gen/users.js",
+        "split_index": 3,
+        "hash": "c1bca0c69a4a541ffcbc5400c8a0fff067e897b3262e1d0dc06c618c36609ab3",
+        "original_index": 103,
+        "locations": "[\"example/ts/flash_gen/users.js:3-233\"]",
+        "end_byte": 12448,
+        "original_hash": "c1bca0c69a4a541ffcbc5400c8a0fff067e897b3262e1d0dc06c618c36609ab3",
+        "end_line": 233,
+        "node_name": "Queries",
+        "language": "javascript",
+        "embedding_model": "text-embedding-3-large",
+        "start_line": 3
+      },
+      "distance": 1.4408736,
+      "cosine_similarity": -0.4408736
+    },
+    {
+      "id": "chunk_13_-5556019581361555733",
+      "content": "async createUser(name, email, address, isadmin) {\n    let stmt = this._stmts.get('createUser');\n    if (!stmt) {\n      stmt = `INSERT INTO users (name, email, address, isadmin) VALUES ($1, $2, $3, $4);`;\n      this._stmts.set('createUser', stmt);\n    }\n    const r = await this.db.query(stmt, [name, email, address, isadmin]);\n    return r.rowCount;\n  }",
+      "metadata": {
+        "content": "async createUser(name, email, address, isadmin) {\n    let stmt = this._stmts.get('createUser');\n    if (!stmt) {\n      stmt = `INSERT INTO users (name, email, address, isadmin) VALUES ($1, $2, $3, $4);`;\n      this._stmts.set('createUser', stmt);\n    }\n    const r = await this.db.query(stmt, [name, email, address, isadmin]);\n    return r.rowCount;\n  }",
+        "locations": "[\"example/ts/flash_gen/users.js:61-69\"]",
+        "node_name": "createUser",
+        "end_byte": 3025,
+        "file_path": "example/ts/flash_gen/users.js",
+        "language": "javascript",
+        "end_line": 69,
+        "original_index": 113,
+        "embedding_model": "text-embedding-3-large",
+        "hash": "158da7597c71e8c597e81493d5a53077b3397362e00132c63bd8c1509cf31ab5",
+        "start_byte": 2672,
+        "start_line": 61,
+        "node_type": "method_definition"
+      },
+      "distance": 1.4469984,
+      "cosine_similarity": -0.4469984
+    }
+  ]
+}

--- a/src/contextinator/utils/output_formatter.py
+++ b/src/contextinator/utils/output_formatter.py
@@ -152,8 +152,32 @@ def export_results_json(results: List[Dict[str, Any]], filepath: str) -> None:
 
 __all__ = [
     'export_results_json',
+    'export_results_toon',
     'format_file_content',
     'format_file_list',
     'format_search_results',
     'format_symbol_list',
 ]
+
+
+def export_results_toon(results: List[Dict[str, Any]], filepath: str) -> None:
+    """
+    Export search results to TOON format file.
+    
+    Args:
+        results: List of search results
+        filepath: Path to output TOON file
+        
+    Raises:
+        FileSystemError: If unable to write file
+    """
+    from .exceptions import FileSystemError
+    from .toon_encoder import toon_encode
+    
+    try:
+        toon_output = toon_encode(results)
+        with open(filepath, 'w', encoding='utf-8') as f:
+            f.write(toon_output)
+        logger.info(f"✅ Results exported to TOON format: {filepath}")
+    except Exception as e:
+        raise FileSystemError(f"Failed to export TOON: {e}", filepath, "write")

--- a/src/contextinator/utils/toon_encoder.py
+++ b/src/contextinator/utils/toon_encoder.py
@@ -1,110 +1,25 @@
 """
 TOON (Token-Oriented Object Notation) encoder for Contextinator.
 
+Wrapper around the official toon-format library.
 Converts JSON structures to compact TOON format, saving 40-60% tokens.
 """
 
 from typing import Any, Dict, List, Union
 
+try:
+    from toon_format import encode as _toon_encode
+    TOON_AVAILABLE = True
+except ImportError:
+    TOON_AVAILABLE = False
 
-def encode_value(value: Any, key: str = "") -> str:
+
+def toon_encode(data: Union[Dict, List, Any]) -> str:
     """
-    Encode a single value to TOON format.
+    Encode data to TOON format using the official toon-format library.
     
     Args:
-        value: Value to encode
-        key: Optional key name for context
-        
-    Returns:
-        TOON-encoded string
-    """
-    if value is None:
-        return "null"
-    elif isinstance(value, bool):
-        return "true" if value else "false"
-    elif isinstance(value, (int, float)):
-        return str(value)
-    elif isinstance(value, str):
-        # Only quote if contains special chars
-        if any(c in value for c in [',', ':', '[', ']', '{', '}', ' ']):
-            return f'"{value}"'
-        return value
-    elif isinstance(value, list):
-        return encode_list(value, key)
-    elif isinstance(value, dict):
-        return encode_dict(value, key)
-    return str(value)
-
-
-def encode_list(items: List[Any], key: str = "") -> str:
-    """
-    Encode list to TOON format: key[n]: item1,item2,item3
-    
-    Args:
-        items: List to encode
-        key: Key name for the list
-        
-    Returns:
-        TOON-encoded list string
-    """
-    if not items:
-        return f"{key}[0]:" if key else "[]"
-    
-    # Simple values - compact format
-    if all(isinstance(item, (str, int, float, bool)) for item in items):
-        encoded_items = [encode_value(item) for item in items]
-        if key:
-            return f"{key}[{len(items)}]: {','.join(encoded_items)}"
-        return ','.join(encoded_items)
-    
-    # Complex values - line by line
-    result = []
-    for i, item in enumerate(items):
-        if isinstance(item, dict):
-            result.append(f"{key}[{i}]: {encode_dict(item)}")
-        else:
-            result.append(f"{key}[{i}]: {encode_value(item)}")
-    return '\n'.join(result)
-
-
-def encode_dict(obj: Dict[str, Any], prefix: str = "") -> str:
-    """
-    Encode dictionary to TOON format with dot notation.
-    
-    Args:
-        obj: Dictionary to encode
-        prefix: Prefix for nested keys
-        
-    Returns:
-        TOON-encoded dictionary string
-    """
-    if not obj:
-        return "{}"
-    
-    lines = []
-    for key, value in obj.items():
-        full_key = f"{prefix}.{key}" if prefix else key
-        
-        if isinstance(value, dict):
-            # Nested object - flatten with dot notation
-            lines.append(encode_dict(value, full_key))
-        elif isinstance(value, list):
-            # List - use compact array notation
-            lines.append(encode_list(value, full_key))
-        else:
-            # Simple value
-            lines.append(f"{full_key}: {encode_value(value)}")
-    
-    return '\n'.join(lines)
-
-
-def toon_encode(data: Union[Dict, List], root_key: str = "data") -> str:
-    """
-    Main TOON encoding function.
-    
-    Args:
-        data: Data structure to encode (dict or list)
-        root_key: Root key name for the structure
+        data: Data structure to encode (dict, list, or primitive)
         
     Returns:
         TOON-encoded string
@@ -114,13 +29,17 @@ def toon_encode(data: Union[Dict, List], root_key: str = "data") -> str:
         >>> print(toon_encode(data))
         tags[3]: jazz,chill,lofi
         count: 3
+        
+    Raises:
+        ImportError: If toon-format library is not installed
     """
-    if isinstance(data, dict):
-        return encode_dict(data)
-    elif isinstance(data, list):
-        return encode_list(data, root_key)
-    else:
-        return encode_value(data)
+    if not TOON_AVAILABLE:
+        raise ImportError(
+            "toon-format library not installed. "
+            "Install with: pip install toon-format==0.9.0b1"
+        )
+    
+    return _toon_encode(data)
 
 
 __all__ = ['toon_encode']


### PR DESCRIPTION
added toon from official library.

to test use this python -m src.contextinator.cli search ""your query --collection name --toon results.json

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Integrated official TOON format export to reduce LLM prompt tokens by ~40–60% and added CLI support to write search and symbol results in TOON.

- **New Features**
  - Add --toon flag to search and symbol commands to write TOON files (usage added to README).
  - Add export_results_toon to generate TOON output.

- **Refactors**
  - Replace custom encoder with a thin wrapper around the official toon-format library (new dependency: toon-format>=0.9.0b1).

<sup>Written for commit 95f2f42781307c5fb60c7b21115c37dc02f02355. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

