### PR TITLE
fiuxed all the bugs for public release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,12 +20,15 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Code Generators",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 dependencies = [
     "tree-sitter>=0.25.0",
     "chromadb>=1.3.0",

--- a/src/contextinator/cli.py
+++ b/src/contextinator/cli.py
@@ -62,7 +62,11 @@ def embed_func(args):
     from .utils.repo_utils import extract_repo_name_from_url
     from pathlib import Path
     import os
+    # Set API key if provided
     
+    if hasattr(args, 'api_key') and args.api_key:
+        os.environ['OPENAI_API_KEY'] = args.api_key
+         
     try:
         repo_url = getattr(args, 'repo_url', None)
         
@@ -250,7 +254,8 @@ def search_func(args):
             query=query,
             n_results=args.n_results,
             language=getattr(args, 'language', None),
-            include_parents=getattr(args, 'include_parents', False)
+            include_parents=getattr(args, 'include_parents', False),
+            chromadb_dir=getattr(args, 'chromadb_dir', None)
         )
 
         
@@ -285,6 +290,7 @@ def symbol_func(args):
             collection_name=args.collection,
             symbol_name=args.symbol_name,
             symbol_type=getattr(args, 'type', None),
+            chromadb_dir=getattr(args, 'chromadb_dir', None)
         )
         
         result_data = {
@@ -630,6 +636,7 @@ def main():
     p_embed.add_argument('--output', '-o', help='Base directory containing chunks folder (default: current directory)')
     p_embed.add_argument('--chunks-dir', help='Custom chunks directory (overrides default .contextinator/chunks)')
     p_embed.add_argument('--embeddings-dir', help='Custom embeddings directory (overrides default .contextinator/embeddings)')
+    p_embed.add_argument('--api-key', help='OpenAI API key (alternative to OPENAI_API_KEY env var)')  
     p_embed.set_defaults(func=embed_func)
 
     # store-embeddings
@@ -653,6 +660,7 @@ def main():
     p_pipeline.add_argument('--embeddings-dir', help='Custom embeddings directory (overrides default .contextinator/embeddings)')
     p_pipeline.add_argument('--chromadb-dir', help='Custom chromadb directory (overrides default .contextinator/chromadb)')
     p_pipeline.add_argument('--collection-name', help='Custom collection name (default: repository name)')
+    p_pipeline.add_argument('--api-key', help='OpenAI API key (alternative to OPENAI_API_KEY env var)')   
     p_pipeline.set_defaults(func=pipeline_func)
 
     # query
@@ -716,6 +724,7 @@ def main():
     p_search.add_argument('--include-parents', action='store_true', help='Include parent chunks (classes/modules) in results')
     p_search.add_argument('--json', help='Export results to JSON file')
     p_search.add_argument('--toon', help='Export results to TOON file (compact format)')
+    p_search.add_argument('--chromadb-dir', help='Custom chromadb directory (overrides default .contextinator/chromadb)')
     p_search.set_defaults(func=search_func)
 
     # symbol (symbol search)
@@ -737,6 +746,7 @@ def main():
     p_symbol.add_argument('--limit', type=int, default=50, help='Maximum results (default: 50)')
     p_symbol.add_argument('--json', help='Export results to JSON file')
     p_symbol.add_argument('--toon', help='Export results to TOON file (compact format)')
+    p_symbol.add_argument('--chromadb-dir', help='Custom chromadb directory (overrides default .contextinator/chromadb)')
     p_symbol.set_defaults(func=symbol_func)
 
     # pattern (regex search)
@@ -759,6 +769,7 @@ def main():
     p_pattern.add_argument('--limit', type=int, default=50, help='Maximum results (default: 50)')
     p_pattern.add_argument('--json', help='Export results to JSON file')
     p_pattern.add_argument('--toon', help='Export results to TOON file (compact format)')
+    p_pattern.add_argument('--chromadb-dir', help='Custom chromadb directory (overrides default .contextinator/chromadb)')
     p_pattern.set_defaults(func=pattern_func)
 
     # read-file (file reconstruction)
@@ -768,6 +779,7 @@ def main():
     p_read_file.add_argument('--no-join', action='store_true', help='Show chunks separately (don\'t join)')
     p_read_file.add_argument('--json', help='Export to JSON file')
     p_read_file.add_argument('--toon', help='Export to TOON file (compact format)')
+    p_read_file.add_argument('--chromadb-dir', help='Custom chromadb directory (overrides default .contextinator/chromadb)')
     p_read_file.set_defaults(func=read_file_func)
 
     # search-advanced (advanced/hybrid search)
@@ -795,6 +807,7 @@ def main():
     p_search_adv.add_argument('--limit', type=int, default=50, help='Maximum results (default: 50)')
     p_search_adv.add_argument('--json', help='Export results to JSON file')
     p_search_adv.add_argument('--toon', help='Export results to TOON file (compact format)')
+    p_search_adv.add_argument('--chromadb-dir', help='Custom chromadb directory (overrides default .contextinator/chromadb)')
     p_search_adv.set_defaults(func=search_advanced_func)
 
     args = parser.parse_args()

--- a/src/contextinator/tools/__init__.py
+++ b/src/contextinator/tools/__init__.py
@@ -29,7 +29,7 @@ class SearchTool:
     search results across different search strategies.
     """
     
-    def __init__(self, collection_name: str, base_dir: Optional[str] = None, repo_name: Optional[str] = None) -> None:
+    def __init__(self, collection_name: str, base_dir: Optional[str] = None, repo_name: Optional[str] = None, chromadb_dir: Optional[str] = None) -> None:
         """
         Initialize search tool with ChromaDB connection.
         
@@ -48,6 +48,7 @@ class SearchTool:
             raise ValidationError("Collection name cannot be empty", "collection_name", "non-empty string")
             
         self.collection_name = collection_name
+        self.chromadb_dir = chromadb_dir
         
         try:
             self.client = self._get_client()
@@ -82,7 +83,10 @@ class SearchTool:
             
             # Use local client
             from pathlib import Path
-            db_path = str(Path.cwd() / '.chromadb')
+            if self.chromadb_dir:
+                db_path = str(Path(self.chromadb_dir))
+            else:
+                db_path = str(Path.cwd() / '.chromadb')
             return chromadb.PersistentClient(path=db_path)
             
         except Exception as e:

--- a/src/contextinator/tools/semantic_search.py
+++ b/src/contextinator/tools/semantic_search.py
@@ -35,7 +35,8 @@ def semantic_search(
     language: Optional[str] = None,
     file_path: Optional[str] = None,
     node_type: Optional[str] = None,
-    include_parents: bool = False
+    include_parents: bool = False,
+    chromadb_dir: Optional[str] = None
 ) -> List[Dict[str, Any]]:
     """
     Search for semantically similar code using natural language queries.
@@ -83,7 +84,7 @@ def semantic_search(
     try:
         # Pattern 2: Handle missing collection gracefully
         try:
-            tool = SearchTool(collection_name)
+            tool = SearchTool(collection_name, chromadb_dir=chromadb_dir)
         except ValueError as e:
             # Collection doesn't exist
             logger.warning(f"Collection '{collection_name}' not found: {e}")

--- a/src/contextinator/tools/symbol_search.py
+++ b/src/contextinator/tools/symbol_search.py
@@ -51,7 +51,8 @@ def symbol_search(
     symbol_name: str,
     symbol_type: Optional[str] = None,
     language: Optional[str] = None,
-    exact_match: bool = True
+    exact_match: bool = True,
+    chromadb_dir: Optional[str] = None
 ) -> List[Dict[str, Any]]:
     """
     Search for specific symbols (functions, classes, variables) by name.
@@ -79,7 +80,7 @@ def symbol_search(
     
     try:
         tool = SearchTool(collection_name)
-        
+        tool = SearchTool(collection_name, chromadb_dir=chromadb_dir)        
         # Build where clause (get() doesn't support $contains)
         where = {}
         if language:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Expanded Python support to 3.10+ and added CLI options for setting the OpenAI API key and a custom ChromaDB directory, improving setup and making searches more reliable.

- **New Features**
  - Requires Python >=3.10; added classifiers for 3.10–3.12.
  - --api-key for embed and pipeline; sets OPENAI_API_KEY automatically.
  - --chromadb-dir added to search, symbol, pattern, read-file, and advanced search.
  - SearchTool, semantic_search, and symbol_search accept chromadb_dir for a custom DB path.

- **Bug Fixes**
  - Correctly passes chromadb_dir from CLI to SearchTool to prevent search failures.
  - Uses the specified ChromaDB path for the persistent client to avoid default path collisions.

<sup>Written for commit a3f0ed51fce7c52083860c95ec1c6ada64ea1256. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

